### PR TITLE
Add media query so text-box does not cover entire display in mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,13 +10,14 @@
 </head>
 <body id="js-body">
 
-  <section>
+  <section class="text-box">
+
     <span class="title">GIF-orecast</span>
     <span class="city"></span></br>
     <span class="summary">Loading...</span></br>
     <span class="temperature"></span>
 
-  </section>
+  </section class="text-box">
 
   <script src="./api-keys.js"></script>
   <script src="public/assets/js/app.js"></script>

--- a/public/assets/style/style.css
+++ b/public/assets/style/style.css
@@ -10,20 +10,26 @@ body {
   height: 100%;
 }
 
-section{
+.text-box {
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
   background-color: rgba(255, 255, 255, 0.7);
   padding: 2rem;
-  border-radius: 2em;
+  border-radius: 2rem;
   text-align: center;
   box-shadow: 10px 10px 5px black;
 }
 
+@media (max-width: 520px) {
+  .text-box {
+    max-width: 50%;
+  }
+}
+
 .title {
-  font-size: 4rem;
+  font-size: 3rem;
   color: black;
   text-align: center;
 }


### PR DESCRIPTION
When screen width is less than 520px, the text-box has a max-width of 50%. Relates #66. 

And gave a class name to section in html so that css is more understandable. relates #73. 

Also changed a stray em to rem. 
